### PR TITLE
Set `-uroot-source` for the Mullvad specific targets as well

### DIFF
--- a/tasks/stboot.yml
+++ b/tasks/stboot.yml
@@ -267,6 +267,7 @@ tasks:
         silent: true
       - >
         {{.GOPREFIX}} {{.GOBIN}}/u-root -build=bb
+        -uroot-source ./cache/go/src/{{.UROOT_REPO}}
         -o {{.INITRAMFS}} {{.FILES_ARGS}} {{.PKGS_ARGS}}
       - gzip -kf {{.INITRAMFS}}
     env:
@@ -318,6 +319,7 @@ tasks:
         silent: true
       - >
         {{.GOPREFIX}} {{.GOBIN}}/u-root -build=bb
+        -uroot-source ./cache/go/src/{{.UROOT_REPO}}
         -o {{.INITRAMFS}} {{.FILES_ARGS}} {{.PKGS_ARGS}}
       - gzip -kf {{.INITRAMFS}}
     env:


### PR DESCRIPTION
The `-uroot-source` command line argument is needed in modern u-root, see u-root/README.